### PR TITLE
feat(report): normalized indicator

### DIFF
--- a/apps/website/src/components/SearchModal.tsx
+++ b/apps/website/src/components/SearchModal.tsx
@@ -70,7 +70,7 @@ export function SearchModal() {
                 leaveFrom="opacity-100 scale-100"
                 leaveTo="opacity-0 scale-95"
               >
-                <Dialog.Panel className="mx-auto w-full relative transform overflow-hidden md:rounded-xl bg-white shadow-2xl transition-all flex flex-col h-full md:h-auto max-h-full">
+                <Dialog.Panel className="mx-auto w-full relative transform overflow-hidden md:rounded-xl bg-white shadow-2xl transition-all flex flex-col h-full md:h-auto max-h-full pb-20 md:pb-0">
                   <div className="h-[56px] md:h-[68px] flex items-center shadow z-40 absolute top-0 inset-x-0 bg-white">
                     <div className="flex items-center justify-center flex-shrink-0 pl-5 pr-3 md:px-5">
                       {/* {data ? (
@@ -100,14 +100,14 @@ export function SearchModal() {
                   </div>
 
                   <div className="overflow-y-scroll relative">
-                    <ChatModal ref={chatRef} />
-                    <div className="p-6 md:py-24 space-y-8 h-full">
+                    <div className="px-6 pt-20 md:py-24 space-y-8 h-full">
                       {showWritersBlock && <WritersBlock />}
                       {!showWritersBlock && (
                         <NewReport name={parseNameResponse} />
                       )}
                     </div>
                   </div>
+                  <ChatModal ref={chatRef} />
                   <div className="absolute bottom-0 inset-x-0 z-20">
                     <SearchFooter />
                   </div>

--- a/packages/nameguard-react/src/Banner.tsx
+++ b/packages/nameguard-react/src/Banner.tsx
@@ -85,7 +85,7 @@ export function Banner({ report, parsedName }: Props) {
   return (
     <div className={wrapperClass}>
       <div className="p-5 md:py-7 md:px-10 flex flex-col md:flex-row md:items-start justify-between">
-        <div className="md:w-4/6 overflow-hidden overflow-ellipsis whitespace-nowrap">
+        <div className="md:w-4/6 overflow-hidden overflow-ellipsis">
           <p className="uppercase text-[12px] text-gray-500 font-medium">
             Rating for
           </p>
@@ -107,7 +107,7 @@ export function Banner({ report, parsedName }: Props) {
           </div>
           <div className="space-y-1">
             <p className={text}>{title}</p>
-            <p className="text-black text-sm font-normal leading-6">
+            <p className="text-black text-sm font-normal leading-6 break-all">
               {subtitle}
             </p>
           </div>

--- a/packages/nameguard-react/src/LabelList.tsx
+++ b/packages/nameguard-react/src/LabelList.tsx
@@ -1,0 +1,73 @@
+import React, { Fragment } from "react";
+import type { NameGuardReport } from "@namehash/nameguard";
+import { ShieldExclamationIcon } from "@heroicons/react/20/solid";
+
+import { UnknownGraphemeCard } from "./UnknownGraphemeCard";
+import { GraphemeCard } from "./GraphemeCard";
+
+type LabelListProps = {
+  items?: NameGuardReport["labels"];
+};
+
+export function LabelList({ items = [] }: LabelListProps) {
+  const rawLabels = items.map((i) => i.label) ?? [];
+
+  return items?.map((label, index) => {
+    const unknown = label.normalization === "unknown";
+    const empty = label.label === "";
+
+    return (
+      <div
+        key={index}
+        className="border border-gray-200 rounded-md divide-y divide-gray-200"
+      >
+        <div className="py-[10px] px-6 md:flex md:items-center md:justify-between space-y-1 md:space-y-0">
+          <div className="text-sm font-normal break-all">
+            {rawLabels.map((l, index) => (
+              <Fragment key={index}>
+                <span
+                  className={
+                    l === label.label
+                      ? "text-black font-semibold"
+                      : "text-gray-500 grayscale"
+                  }
+                >
+                  {l === "" ? "[empty]" : l}
+                </span>
+                {index < rawLabels.length - 1 && (
+                  <span className="text-gray-500">.</span>
+                )}
+              </Fragment>
+            ))}
+          </div>
+          {(label.normalization === "unnormalized" ||
+            label.normalization === "unknown") && (
+            <div className="flex items-center space-x-2">
+              <ShieldExclamationIcon className="w-4 h-4 text-red-600 fill-current" />
+              <span className="text-red-600 text-sm">
+                {label.normalization === "unnormalized"
+                  ? "Not ENS Normalized"
+                  : "Not found"}
+              </span>
+            </div>
+          )}
+        </div>
+        {unknown && (
+          <UnknownGraphemeCard
+            title="Unknown label"
+            description="This part of the name was registered in a way that makes it unknown."
+          />
+        )}
+        {empty && (
+          <UnknownGraphemeCard
+            title="Empty label"
+            description="This part of the name is empty."
+          />
+        )}
+        {label?.graphemes?.map((grapheme, index) => (
+          <GraphemeCard key={index} {...grapheme} />
+        ))}
+      </div>
+    );
+  });
+}

--- a/packages/nameguard-react/src/LabelList.tsx
+++ b/packages/nameguard-react/src/LabelList.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 import type { NameGuardReport } from "@namehash/nameguard";
 import { ShieldExclamationIcon } from "@heroicons/react/20/solid";
 
-import { UnknownGraphemeCard } from "./UnknownGraphemeCard";
+import { NoGraphemesWarning } from "./NoGraphemesWarning";
 import { GraphemeCard } from "./GraphemeCard";
 
 type LabelListProps = {
@@ -53,13 +53,13 @@ export function LabelList({ items = [] }: LabelListProps) {
           )}
         </div>
         {unknown && (
-          <UnknownGraphemeCard
+          <NoGraphemesWarning
             title="Unknown label"
             description="This part of the name was registered in a way that makes it unknown."
           />
         )}
         {empty && (
-          <UnknownGraphemeCard
+          <NoGraphemesWarning
             title="Empty label"
             description="This part of the name is empty."
           />

--- a/packages/nameguard-react/src/NoGraphemesWarning.tsx
+++ b/packages/nameguard-react/src/NoGraphemesWarning.tsx
@@ -8,7 +8,7 @@ type Props = {
   description: string;
 };
 
-export function UnknownGraphemeCard({ title, description }: Props) {
+export function NoGraphemesWarning({ title, description }: Props) {
   return (
     <div className="bg-red-50 grid grid-cols-8 lg:grid-cols-12 gap-4 py-5 pl-6 rounded-b-md">
       <div className="flex md:items-center justify-center">

--- a/packages/nameguard-react/src/Report.tsx
+++ b/packages/nameguard-react/src/Report.tsx
@@ -1,8 +1,16 @@
 import React, { Fragment } from "react";
 
 import { Banner, CheckResultCard, GraphemeCard, ReportFooter } from ".";
+import type { NameGuardReport } from "@namehash/nameguard";
+import { ShieldExclamationIcon } from "@heroicons/react/20/solid";
+import { UnknownGraphemeCard } from "./UnknownGraphemeCard";
 
-export const Report = (props: any) => {
+type Props = {
+  parseNameResponse: unknown;
+  data: NameGuardReport;
+};
+
+export const Report = (props: Props) => {
   const { parseNameResponse, data } = props;
 
   const rawLabels = data?.labels.map((label) => label.label) ?? [];
@@ -33,24 +41,49 @@ export const Report = (props: any) => {
             key={index}
             className="border border-gray-200 rounded-md divide-y divide-gray-200"
           >
-            <div className="py-[10px] px-6 text-sm font-normal">
-              {rawLabels.map((l, index) => (
-                <Fragment key={index}>
-                  <span
-                    className={
-                      l === label.label
-                        ? "text-black font-semibold"
-                        : "text-gray-500 grayscale"
-                    }
-                  >
-                    {l}
+            <div className="py-[10px] px-6 md:flex md:items-center md:justify-between space-y-1 md:space-y-0">
+              <div className="text-sm font-normal break-all">
+                {rawLabels.map((l, index) => (
+                  <Fragment key={index}>
+                    <span
+                      className={
+                        l === label.label
+                          ? "text-black font-semibold"
+                          : "text-gray-500 grayscale"
+                      }
+                    >
+                      {l}
+                    </span>
+                    {index < rawLabels.length - 1 && (
+                      <span className="text-gray-500">.</span>
+                    )}
+                  </Fragment>
+                ))}
+              </div>
+              {(label.normalization === "unnormalized" ||
+                label.normalization === "unknown") && (
+                <div className="flex items-center space-x-2">
+                  <ShieldExclamationIcon className="w-4 h-4 text-red-600 fill-current" />
+                  <span className="text-red-600 text-sm">
+                    {label.normalization === "unnormalized"
+                      ? "Not ENS Normalized"
+                      : "Not found"}
                   </span>
-                  {index < rawLabels.length - 1 && (
-                    <span className="text-gray-500">.</span>
-                  )}
-                </Fragment>
-              ))}
+                </div>
+              )}
             </div>
+            {label?.normalization === "unknown" && (
+              <UnknownGraphemeCard
+                title="Unknown label"
+                description="This part of the name was registered in a way that makes it unknown."
+              />
+            )}
+            {label?.graphemes?.length === 0 && (
+              <UnknownGraphemeCard
+                title="Empty label"
+                description="This part of the name is empty."
+              />
+            )}
             {label?.graphemes?.map((grapheme, index) => (
               <GraphemeCard key={index} {...grapheme} />
             ))}

--- a/packages/nameguard-react/src/Report.tsx
+++ b/packages/nameguard-react/src/Report.tsx
@@ -1,9 +1,7 @@
 import React, { Fragment } from "react";
 
-import { Banner, CheckResultCard, GraphemeCard, ReportFooter } from ".";
+import { Banner, CheckResultCard, LabelList, ReportFooter } from ".";
 import type { NameGuardReport } from "@namehash/nameguard";
-import { ShieldExclamationIcon } from "@heroicons/react/20/solid";
-import { UnknownGraphemeCard } from "./UnknownGraphemeCard";
 
 type Props = {
   parseNameResponse: unknown;
@@ -12,8 +10,6 @@ type Props = {
 
 export const Report = (props: Props) => {
   const { parseNameResponse, data } = props;
-
-  const rawLabels = data?.labels.map((label) => label.label) ?? [];
 
   if (!parseNameResponse || !data) return null;
 
@@ -36,59 +32,7 @@ export const Report = (props: Props) => {
           Name inspection
         </p>
 
-        {data?.labels.map((label, index) => (
-          <div
-            key={index}
-            className="border border-gray-200 rounded-md divide-y divide-gray-200"
-          >
-            <div className="py-[10px] px-6 md:flex md:items-center md:justify-between space-y-1 md:space-y-0">
-              <div className="text-sm font-normal break-all">
-                {rawLabels.map((l, index) => (
-                  <Fragment key={index}>
-                    <span
-                      className={
-                        l === label.label
-                          ? "text-black font-semibold"
-                          : "text-gray-500 grayscale"
-                      }
-                    >
-                      {l}
-                    </span>
-                    {index < rawLabels.length - 1 && (
-                      <span className="text-gray-500">.</span>
-                    )}
-                  </Fragment>
-                ))}
-              </div>
-              {(label.normalization === "unnormalized" ||
-                label.normalization === "unknown") && (
-                <div className="flex items-center space-x-2">
-                  <ShieldExclamationIcon className="w-4 h-4 text-red-600 fill-current" />
-                  <span className="text-red-600 text-sm">
-                    {label.normalization === "unnormalized"
-                      ? "Not ENS Normalized"
-                      : "Not found"}
-                  </span>
-                </div>
-              )}
-            </div>
-            {label?.normalization === "unknown" && (
-              <UnknownGraphemeCard
-                title="Unknown label"
-                description="This part of the name was registered in a way that makes it unknown."
-              />
-            )}
-            {label?.graphemes?.length === 0 && (
-              <UnknownGraphemeCard
-                title="Empty label"
-                description="This part of the name is empty."
-              />
-            )}
-            {label?.graphemes?.map((grapheme, index) => (
-              <GraphemeCard key={index} {...grapheme} />
-            ))}
-          </div>
-        ))}
+        <LabelList items={data.labels} />
       </div>
       <ReportFooter />
     </Fragment>

--- a/packages/nameguard-react/src/UnknownGraphemeCard.tsx
+++ b/packages/nameguard-react/src/UnknownGraphemeCard.tsx
@@ -11,7 +11,7 @@ type Props = {
 export function UnknownGraphemeCard({ title, description }: Props) {
   return (
     <div className="bg-red-50 grid grid-cols-8 lg:grid-cols-12 gap-4 py-5 pl-6 rounded-b-md">
-      <div className="flex md:items-center justify-center flex-shrink-0">
+      <div className="flex md:items-center justify-center">
         <div className="bg-red-100 rounded-full w-12 h-12 flex items-center justify-center flex-shrink-0">
           <ShieldExclamationIcon className="w-6 h-6 text-red-600 fill-current" />
         </div>

--- a/packages/nameguard-react/src/UnknownGraphemeCard.tsx
+++ b/packages/nameguard-react/src/UnknownGraphemeCard.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ShieldExclamationIcon } from "@heroicons/react/20/solid";
+
+import { Check } from "./Check";
+
+type Props = {
+  title: string;
+  description: string;
+};
+
+export function UnknownGraphemeCard({ title, description }: Props) {
+  return (
+    <div className="bg-red-50 grid grid-cols-8 lg:grid-cols-12 gap-4 py-5 pl-6 rounded-b-md">
+      <div className="flex md:items-center justify-center flex-shrink-0">
+        <div className="bg-red-100 rounded-full w-12 h-12 flex items-center justify-center flex-shrink-0">
+          <ShieldExclamationIcon className="w-6 h-6 text-red-600 fill-current" />
+        </div>
+      </div>
+      <div className="md:grid md:grid-cols-7 md:gap-4 col-span-7 md:col-span-11 flex items-center md:flex-none flex-wrap">
+        <div className="md:col-span-3 flex items-center w-full">
+          <p className="text-black text-lg md:text-sm font-semibold md:font-medium">
+            {title}
+          </p>
+        </div>
+
+        <div className="md:col-span-4 flex justify-between space-x-3 w-full">
+          <div className="flex flex-row-reverse md:flex-row items-center justify-between md:justify-start space-y-1 md:space-y-0 md:space-x-2 flex-1 pr-6 md:pr-12">
+            <Check code="alert" />
+            <p className="md:font-medium text-gray-500 md:text-black text-sm w-full">
+              {description}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/nameguard-react/src/index.ts
+++ b/packages/nameguard-react/src/index.ts
@@ -8,3 +8,4 @@ export { Tooltip } from "./Tooltip";
 export { CheckResultCard } from "./CheckResultCard";
 export { LabelList } from "./LabelList";
 export { GraphemeCard } from "./GraphemeCard";
+export { NoGraphemesWarning } from "./NoGraphemesWarning";

--- a/packages/nameguard-react/src/index.ts
+++ b/packages/nameguard-react/src/index.ts
@@ -6,4 +6,5 @@ export { Shield } from "./Shield";
 export { Check } from "./Check";
 export { Tooltip } from "./Tooltip";
 export { CheckResultCard } from "./CheckResultCard";
+export { LabelList } from "./LabelList";
 export { GraphemeCard } from "./GraphemeCard";


### PR DESCRIPTION
Figma shows a different shield but heroicons didn't export this icon. Is it an old icon/library?

PS. In another PR we can refactor the `Report` component and add ` GraphemeList` that handles the logic for displaying unknow/empty notices.