### PR TITLE
feat(sdk): AbortController

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namehash/nameguard",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -165,7 +165,7 @@ describe("NameGuard", () => {
 
     expect(data.primary_name_status).toBe("normalized");
     expect(data.impersonation_status).toBe("unlikely");
-    expect(data.primary_name).toBe("vincξnt.eth")
+    expect(data.primary_name).toBe("vincξnt.eth");
     expect(data.display_name).toBe("vincΞnt.eth");
     expect(data.nameguard_result).not.toBeNull();
     expect(data.nameguard_result?.name).toBe("vincξnt.eth");
@@ -185,7 +185,4 @@ describe("NameGuard", () => {
     expect(data.nameguard_result?.name).toBe("hello<world>!.eth");
     expect(data.nameguard_result?.canonical_name).toBeNull();
   });
-  
-  // 
-
 });


### PR DESCRIPTION
I forgot to push this on Saturday but I was using the SDK with an input similar to what you see on nameguard.io but there was no way to abort current requests. Also includes some minimal refactoring.