### PR TITLE
Modal UI Changes

### DIFF
--- a/packages/nameguard-react/src/components/GraphemeModal/GraphemeModal.tsx
+++ b/packages/nameguard-react/src/components/GraphemeModal/GraphemeModal.tsx
@@ -19,6 +19,9 @@ export const GraphemeModal = forwardRef((_, ref: Ref<HTMLDivElement>) => {
     (g: string) => nameguard.inspectGrapheme(g)
   );
 
+  const totalCodepoints = data?.codepoints?.length ?? 0;
+  const [firstCodepoint] = data?.codepoints ?? [];
+
   const handleClose = () => {
     closeGraphemeModal(currentGrapheme);
   };
@@ -59,8 +62,11 @@ export const GraphemeModal = forwardRef((_, ref: Ref<HTMLDivElement>) => {
               <div className="flex items-start justify-center space-x-10 border-t border-gray-200 mt-10 pt-10">
                 <div className="space-y-1">
                   <p className="text-gray-500 text-sm">Codepoints</p>
-                  <p className="text-black text-sm font-semibold">
-                    {data?.codepoints}
+                  <p className="text-sm font-semibold">
+                    <span className="text-black">{firstCodepoint}</span>
+                    <span className="text-gray-500">
+                      {totalCodepoints > 1 && ` + ${totalCodepoints - 1} more`}
+                    </span>
                   </p>
                 </div>
                 <div className="space-y-1">

--- a/packages/nameguard-react/src/components/Report/ReportChangesApplied.tsx
+++ b/packages/nameguard-react/src/components/Report/ReportChangesApplied.tsx
@@ -37,7 +37,7 @@ export function ReportChangesApplied({ transformations = [] }: Props) {
         </div>
         <div className="md:flex-shrink-0 hidden md:flex md:items-center md:justify-end">
           <button
-            className="text-xs text-black leading-5 appearance-none underline sm:underline-offset-[4px] sm:transition-all sm:duration-200 sm:hover:underline-offset-[2px]"
+            className="text-sm text-black leading-5 appearance-none underline sm:underline-offset-[4px] sm:transition-all sm:duration-200 sm:hover:underline-offset-[2px]"
             onClick={openSettingsModal}
           >
             Manage settings

--- a/packages/nameguard-react/src/components/Report/ReportChangesApplied.tsx
+++ b/packages/nameguard-react/src/components/Report/ReportChangesApplied.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { useSettingsStore } from "../../stores/settings";
+
 type Props = {
   transformations?: any[];
 };
@@ -11,23 +13,35 @@ const transformationText = {
 };
 
 export function ReportChangesApplied({ transformations = [] }: Props) {
+  const { openModal: openSettingsModal } = useSettingsStore();
+
   if (transformations.length === 0) return null;
 
   return (
     <div className="border-t border-gray-200 mx-6 md:mx-0">
-      <div className="w-full md:px-10 py-4 md:py-3 flex items-center flex-wrap">
-        <span className="text-sm text-gray-500 mr-2.5 w-full md:w-auto">
-          Changes applied to your search:
-        </span>
-        <div className="space-x-1.5 flex items-center mt-2 md:mt-0">
-          {transformations.map((t, i) => (
-            <span
-              className="bg-gray-100 rounded-full px-3 py-0.5 text-sm font-medium text-black"
-              key={i}
-            >
-              {transformationText[t]}
-            </span>
-          ))}
+      <div className="md:px-10 py-4 md:py-3 flex items-center justify-between">
+        <div className="w-full flex items-center flex-wrap">
+          <span className="text-sm text-gray-500 mr-2.5 w-full md:w-auto">
+            Changes applied to your search:
+          </span>
+          <div className="space-x-1.5 flex items-center mt-2 md:mt-0">
+            {transformations.map((t, i) => (
+              <span
+                className="bg-gray-100 rounded-full px-3 py-0.5 text-sm font-medium text-black"
+                key={i}
+              >
+                {transformationText[t]}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="md:flex-shrink-0 hidden md:flex md:items-center md:justify-end">
+          <button
+            className="text-xs text-black leading-5 appearance-none underline sm:underline-offset-[4px] sm:transition-all sm:duration-200 sm:hover:underline-offset-[2px]"
+            onClick={openSettingsModal}
+          >
+            Manage settings
+          </button>
         </div>
       </div>
     </div>

--- a/packages/nameguard-react/src/components/Search/SearchEmptyState.tsx
+++ b/packages/nameguard-react/src/components/Search/SearchEmptyState.tsx
@@ -38,7 +38,13 @@ export const SearchEmptyState = () => {
 
   const { data, isLoading } = useSWR<BulkConsolidatedNameGuardReport>(
     examples.join(),
-    (_) => nameguard.bulkInspectNames(parsedNames.map((n) => n.outputName.name))
+    (_) =>
+      nameguard.bulkInspectNames(parsedNames.map((n) => n.outputName.name)),
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
   );
 
   useEffect(() => {

--- a/packages/nameguard-react/src/components/Search/SearchModal.tsx
+++ b/packages/nameguard-react/src/components/Search/SearchModal.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useRef, useEffect } from "react";
 import { Transition, Dialog } from "@headlessui/react";
 
 import { useSettingsStore } from "../../stores/settings";
@@ -13,11 +13,19 @@ export const SearchModal = () => {
   const { name, modalOpen, closeModal } = useSearchStore();
   const { settings, modalOpen: settingsModalOpen } = useSettingsStore();
 
+  const ref = useRef<HTMLDivElement>(null);
+
   const handleClose = () => {
     if (settingsModalOpen) return;
 
     closeModal();
   };
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.scrollTop = 0;
+    }
+  }, [name]);
 
   return (
     <Transition.Root show={modalOpen} as={Fragment}>
@@ -47,7 +55,10 @@ export const SearchModal = () => {
             >
               <Dialog.Panel className="mx-auto w-full relative transform overflow-hidden md:rounded-xl bg-white shadow-2xl transition-all flex flex-col h-full md:h-auto max-h-full pt-[56px] md:pt-[68px]">
                 <SearchModalHeader />
-                <div className="overflow-y-scroll relative px-6 py-6 md:py-10 h-full">
+                <div
+                  className="overflow-y-scroll relative px-6 py-6 md:py-10 h-full"
+                  ref={ref}
+                >
                   <Report
                     name={name}
                     settings={settings}


### PR DESCRIPTION
Fixes:

* NameGuard: Auto-scroll users to top whenever name being viewed changes
* Fix Handling of Multiple Codepoint Graphemes
* Add dynamic "Manage Settings" link
* bulk-inspect-names API requests for data already cached on frontend

I won't release to NPM in this merge (so it won't appear in NameKit). I'll push another release out when I fix the NameBadge component sizing for NameKit.