### PR TITLE
Add nameguard inspect sync

### DIFF
--- a/api/nameguard/nameguard.py
+++ b/api/nameguard/nameguard.py
@@ -146,13 +146,22 @@ class NameGuard:
         """
         Inspect a name. A name is a sequence of labels separated by dots.
         A label can be a labelhash or a string.
+        If a labelhash is encountered and `resolve_labelhashes` is `True`, a lookup will be performed.
+        """
+        if resolve_labelhashes:
+            name = await resolve_all_labelhashes_in_name_querying_labelhashes(network_name, name)
+        return self.inspect_name_sync(name, bulk_mode)
+
+    def inspect_name_sync(
+        self, name: str, bulk_mode: bool = False
+    ) -> Union[NameGuardReport, ConsolidatedNameGuardReport]:
+        """
+        Inspect a name. A name is a sequence of labels separated by dots.
+        A label can be a labelhash or a string.
         If a labelhash is encountered, it will be treated as an unknown label.
         """
 
         logger.debug(f"[inspect_name] name: '{name}'")
-
-        if resolve_labelhashes:
-            name = await resolve_all_labelhashes_in_name_querying_labelhashes(network_name, name)
 
         if bulk_mode and simple_name(name):
             return consolidated_report_from_simple_name(name)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nameguard"
-version = "0.1.3"
+version = "0.1.4"
 description = "Security \"x-ray\" for ENS names"
 authors = ["NameHash Team <devops@namehash.io>"]
 maintainers = ["NameHash Team <devops@namehash.io>"]

--- a/api/tests/test_nameguard.py
+++ b/api/tests/test_nameguard.py
@@ -644,3 +644,9 @@ async def test_stress_ens_cure(nameguard: NameGuard):
     # with omit_cure=False takes 1 minute
     result = await nameguard.inspect_name('mainnet', '⎛⎝⎞⎠' * 1000)
     assert result.rating is Rating.ALERT
+
+
+def test_sync_inspect(nameguard: NameGuard):
+    result = nameguard.inspect_name_sync('nick.eth')
+    assert result.rating is Rating.PASS
+    assert all(check.rating is Rating.PASS for check in result.checks)


### PR DESCRIPTION
Adds a non-async version of `inspect_name`. It is equal to the async version with `resolve_labelhashes=False`.
We need this to use nameguard in non-async projects.