### PR TITLE
feat(namekit-react): Button

### DIFF
--- a/.changeset/mighty-bees-explain.md
+++ b/.changeset/mighty-bees-explain.md
@@ -1,0 +1,5 @@
+---
+"@namehash/namekit-react": minor
+---
+
+Button and IconButton components

--- a/apps/storybook/stories/Namekit/Button.stories.tsx
+++ b/apps/storybook/stories/Namekit/Button.stories.tsx
@@ -104,7 +104,7 @@ export const CustomClass: Story = {
     variant: "primary",
     size: "medium",
     children: "Custom Class Button",
-    className: "my-custom-class",
+    className: "custom-class-name",
   },
 };
 

--- a/apps/storybook/stories/Namekit/Button.stories.tsx
+++ b/apps/storybook/stories/Namekit/Button.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Button> = {
     variant: {
       control: {
         type: "select",
-        options: ["primary", "secondary"],
+        options: ["primary", "secondary", "ghost"],
       },
     },
     size: {
@@ -43,6 +43,14 @@ export const SecondaryMedium: Story = {
   },
 };
 
+export const GhostMedium: Story = {
+  args: {
+    variant: "ghost",
+    size: "medium",
+    children: "Ghost Medium Button",
+  },
+};
+
 export const PrimarySmall: Story = {
   args: {
     variant: "primary",
@@ -59,6 +67,14 @@ export const SecondarySmall: Story = {
   },
 };
 
+export const GhostSmall: Story = {
+  args: {
+    variant: "ghost",
+    size: "small",
+    children: "Ghost Small Button",
+  },
+};
+
 export const PrimaryLarge: Story = {
   args: {
     variant: "primary",
@@ -70,6 +86,14 @@ export const PrimaryLarge: Story = {
 export const SecondaryLarge: Story = {
   args: {
     variant: "secondary",
+    size: "large",
+    children: "Secondary Large Button",
+  },
+};
+
+export const GhostLarge: Story = {
+  args: {
+    variant: "ghost",
     size: "large",
     children: "Secondary Large Button",
   },

--- a/apps/storybook/stories/Namekit/Button.stories.tsx
+++ b/apps/storybook/stories/Namekit/Button.stories.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@namehash/namekit-react";
+
+const meta: Meta<typeof Button> = {
+  title: "UI/Button",
+  component: Button,
+  argTypes: {
+    variant: {
+      control: {
+        type: "select",
+        options: ["primary", "secondary"],
+      },
+    },
+    size: {
+      control: {
+        type: "select",
+        options: ["small", "medium", "large"],
+      },
+    },
+    asChild: { control: { disable: true } },
+    children: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const PrimaryMedium: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    children: "Primary Medium Button",
+  },
+};
+
+export const SecondaryMedium: Story = {
+  args: {
+    variant: "secondary",
+    size: "medium",
+    children: "Secondary Medium Button",
+  },
+};
+
+export const PrimarySmall: Story = {
+  args: {
+    variant: "primary",
+    size: "small",
+    children: "Primary Small Button",
+  },
+};
+
+export const SecondarySmall: Story = {
+  args: {
+    variant: "secondary",
+    size: "small",
+    children: "Secondary Small Button",
+  },
+};
+
+export const PrimaryLarge: Story = {
+  args: {
+    variant: "primary",
+    size: "large",
+    children: "Primary Large Button",
+  },
+};
+
+export const SecondaryLarge: Story = {
+  args: {
+    variant: "secondary",
+    size: "large",
+    children: "Secondary Large Button",
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    children: "Custom Class Button",
+    className: "my-custom-class",
+  },
+};
+
+export const AsChild: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    children: "Button as a Link",
+    asChild: <a href="#" />,
+  },
+};

--- a/apps/storybook/stories/Namekit/IconButton.stories.tsx
+++ b/apps/storybook/stories/Namekit/IconButton.stories.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { IconButton } from "@namehash/namekit-react";
+
+const SomeIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M7.50065 6.04175H4.58398C3.54845 6.04175 2.70898 6.88121 2.70898 7.91675V15.4167C2.70898 16.4523 3.54845 17.2917 4.58398 17.2917H15.4173C16.4529 17.2917 17.2923 16.4523 17.2923 15.4167V7.91675C17.2923 6.88121 16.4529 6.04175 15.4173 6.04175H12.5007M12.5007 3.54175L10.0007 1.04175M10.0007 1.04175L7.50065 3.54175M10.0007 1.04175L10.0007 11.6667"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const meta: Meta<typeof IconButton> = {
+  title: "UI/IconButton",
+  component: IconButton,
+  argTypes: {
+    variant: {
+      control: {
+        type: "select",
+        options: ["primary", "secondary", "ghost"],
+      },
+    },
+    size: {
+      control: {
+        type: "select",
+        options: ["small", "medium", "large"],
+      },
+    },
+    className: { control: "text" },
+    iconPosition: {
+      control: {
+        type: "select",
+        options: ["left", "right"],
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+export const PrimaryMedium: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    icon: <SomeIcon />,
+  },
+};
+
+export const SecondaryMedium: Story = {
+  args: {
+    variant: "secondary",
+    size: "medium",
+    icon: <SomeIcon />,
+  },
+};
+
+export const GhostMedium: Story = {
+  args: {
+    variant: "ghost",
+    size: "medium",
+    icon: <SomeIcon />,
+  },
+};
+
+export const PrimarySmall: Story = {
+  args: {
+    variant: "primary",
+    size: "small",
+    icon: <SomeIcon />,
+  },
+};
+
+export const SecondarySmall: Story = {
+  args: {
+    variant: "secondary",
+    size: "small",
+    icon: <SomeIcon />,
+  },
+};
+
+export const GhostSmall: Story = {
+  args: {
+    variant: "ghost",
+    size: "small",
+    icon: <SomeIcon />,
+  },
+};
+
+export const PrimaryLarge: Story = {
+  args: {
+    variant: "primary",
+    size: "large",
+    icon: <SomeIcon />,
+  },
+};
+
+export const SecondaryLarge: Story = {
+  args: {
+    variant: "secondary",
+    size: "large",
+    icon: <SomeIcon />,
+  },
+};
+
+export const CustomClass: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    icon: <SomeIcon />,
+    className: "my-custom-class",
+  },
+};
+
+export const IconRight: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    icon: <SomeIcon />,
+    children: "Icon Right",
+    iconPosition: "right",
+  },
+};
+
+export const PrimaryWithText: Story = {
+  args: {
+    variant: "primary",
+    size: "medium",
+    icon: <SomeIcon />,
+    children: "Share",
+  },
+};
+
+export const SecondaryWithText: Story = {
+  args: {
+    variant: "secondary",
+    size: "medium",
+    icon: <SomeIcon />,
+    children: "Share",
+  },
+};
+
+export const GhostWithText: Story = {
+  args: {
+    variant: "ghost",
+    size: "medium",
+    icon: <SomeIcon />,
+    children: "Share",
+  },
+};

--- a/apps/storybook/stories/Namekit/IconButton.stories.tsx
+++ b/apps/storybook/stories/Namekit/IconButton.stories.tsx
@@ -119,7 +119,7 @@ export const CustomClass: Story = {
     variant: "primary",
     size: "medium",
     icon: <SomeIcon />,
-    className: "my-custom-class",
+    className: "custom-class-name",
   },
 };
 

--- a/packages/namekit-react/src/components/Button.tsx
+++ b/packages/namekit-react/src/components/Button.tsx
@@ -6,15 +6,18 @@ export interface ButtonProps
   asChild?: React.ReactElement;
   className?: string;
   children?: React.ReactNode;
-  variant?: "primary" | "secondary";
+  variant?: "primary" | "secondary" | "ghost";
   size?: "small" | "medium" | "large";
 }
 
-const buttonBaseClasses = "nk-text-base nk-rounded nk-border";
+const buttonBaseClasses =
+  "nk-transition nk-text-base nk-rounded-lg nk-border nk-font-medium";
 
 const variantClasses = {
-  primary: "nk-bg-black nk-text-white nk-border-black",
-  secondary: "nk-bg-white nk-text-black nk-border-gray-200",
+  primary: "nk-bg-black nk-text-white nk-border-black hover:nk-bg-mine-shaft",
+  secondary:
+    "nk-bg-white nk-text-black nk-border-alto nk-shadow-[0_1px_2px_0_rgba(0,0,0,0.05)] hover:nk-bg-gray-50",
+  ghost: "nk-text-black nk-border-transparent hover:nk-bg-black/5",
 };
 
 const sizeClasses = {

--- a/packages/namekit-react/src/components/Button.tsx
+++ b/packages/namekit-react/src/components/Button.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import cc from "classcat";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: React.ReactElement;
+  className?: string;
+  children?: React.ReactNode;
+  variant?: "primary" | "secondary";
+  size?: "small" | "medium" | "large";
+}
+
+const buttonBaseClasses = "nk-text-base nk-rounded nk-border";
+
+const variantClasses = {
+  primary: "nk-bg-black nk-text-white nk-border-black",
+  secondary: "nk-bg-white nk-text-black nk-border-gray-200",
+};
+
+const sizeClasses = {
+  small: "nk-py-1 nk-px-2 nk-text-sm",
+  medium: "nk-py-2 nk-px-4",
+  large: "nk-py-3 nk-px-6 nk-text-lg",
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  asChild,
+  className,
+  children,
+  variant = "primary",
+  size = "medium",
+  ...props
+}) => {
+  const combinedClassName = cc([
+    buttonBaseClasses,
+    variantClasses[variant],
+    sizeClasses[size],
+    className,
+  ]);
+
+  if (asChild) {
+    const childProps = {
+      ...props,
+      ...asChild.props,
+      className: cc([
+        buttonBaseClasses,
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+        asChild.props.className,
+      ]),
+    };
+
+    return React.cloneElement(asChild, childProps, children);
+  }
+
+  return (
+    <button className={combinedClassName} {...props}>
+      {children}
+    </button>
+  );
+};

--- a/packages/namekit-react/src/components/IconButton.tsx
+++ b/packages/namekit-react/src/components/IconButton.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Button, ButtonProps } from "./Button";
+import cc from "classcat";
+
+export interface IconButtonProps extends ButtonProps {
+  icon: React.ReactNode;
+  iconPosition?: "left" | "right";
+}
+
+export const IconButton: React.FC<IconButtonProps> = ({
+  icon,
+  iconPosition = "left",
+  children,
+  className,
+  ...props
+}) => {
+  const combinedClassName = cc([
+    "nk-inline-flex nk-gap-2.5 nk-items-center",
+    className,
+  ]);
+
+  return (
+    <Button className={combinedClassName} {...props}>
+      {iconPosition === "left" && icon}
+      {children}
+      {iconPosition === "right" && icon}
+    </Button>
+  );
+};

--- a/packages/namekit-react/src/index.ts
+++ b/packages/namekit-react/src/index.ts
@@ -5,5 +5,6 @@ import "./styles.css";
 export * from "./components/DomainCard";
 
 export * from "./components/Button";
+export * from "./components/IconButton";
 export * from "./components/Heading";
 export * from "./components/Text";

--- a/packages/namekit-react/src/index.ts
+++ b/packages/namekit-react/src/index.ts
@@ -3,5 +3,7 @@ import "@namehash/ens-webfont";
 import "./styles.css";
 
 export * from "./components/DomainCard";
+
+export * from "./components/Button";
 export * from "./components/Heading";
 export * from "./components/Text";

--- a/packages/namekit-react/tailwind.config.ts
+++ b/packages/namekit-react/tailwind.config.ts
@@ -3,6 +3,14 @@ import type { Config } from "tailwindcss";
 const config: Config = {
   content: ["src/**/*.{ts,tsx,js,jsx,mdx}"],
   prefix: "nk-",
+  theme: {
+    extend: {
+      colors: {
+        alto: "#DBDBDB",
+        "mine-shaft": "#272727",
+      },
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
This PR adds a `Button` component. Styles don't match our branding yet, just setting the foundation for this PR. Button can be used with the usual `asChild` prop so we can use the same variants for TextLinks.

![CleanShot 2024-06-15 at 10 49 29@2x](https://github.com/namehash/nameguard/assets/950181/152e5d14-3081-4547-a53f-51fae558a4aa)

![CleanShot 2024-06-14 at 21 14 59@2x](https://github.com/namehash/nameguard/assets/950181/770de7b3-5095-4299-8468-64e8becc1800)
![CleanShot 2024-06-14 at 21 14 57@2x](https://github.com/namehash/nameguard/assets/950181/fe61a442-7ce8-4926-b9ac-b68c5a09ff73)
![CleanShot 2024-06-14 at 21 14 55@2x](https://github.com/namehash/nameguard/assets/950181/d70ac7a7-03c4-4562-9c9a-f3be1a9231d9)
